### PR TITLE
Change the custom build instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="logo.png"/>
 </p>
 
-**This is a personal fork of lightly where I merge pull requests sent to [Luwx/Lightly](https://github.com/Luwx/Lightly)**
+**This is a personal fork of Lightly where I merge pull requests sent to [Luwx/Lightly](https://github.com/Luwx/Lightly)**
 
 *Lightly* is a fork of breeze theme style that aims to be visually modern and minimalistic.
 
@@ -87,7 +87,7 @@ make
 sudo make install
 ```
 
-For fedora, run `cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib64 -DBUILD_TESTING=OFF ..` instead (#4)
+For RedHat-based distros (like Fedora and OpenSUSE), run `cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib64 -DBUILD_TESTING=OFF ..` instead (#4)
 
 ### Uninstall
 


### PR DESCRIPTION
... to say all RedHat-based distros. I ran the build instructions on OpenSUSE, and not the ones that had to be ran on Fedora, and then I found out that I should've run that on OpenSUSE, so I changed the that (and also fixed some capitalization).