### PR TITLE
Fix translucency for fractional scaling

### DIFF
--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -237,10 +237,6 @@ namespace Lightly
         if( StyleConfigData::opaqueApps().contains(appName, Qt::CaseInsensitive) || StyleConfigData::forceOpaque().contains(appName, Qt::CaseInsensitive) )
             _isOpaque = true;
         
-        const qreal dpr = qApp->devicePixelRatio();
-        bool nonIntegerScale = (dpr > static_cast<qreal>(1) && static_cast<qreal>(qRound(dpr)) != dpr);
-        if( nonIntegerScale ) 
-            _isOpaque = true;
         if(_translucentWidgets.size() > 0) _translucentWidgets.clear();
 
         // base class polishing


### PR DESCRIPTION
This reverts commit 39700ce from the original repo, that disables transparency when using fractional scaling due to a QT bug. Said bug has already been fixed and disabling transparency is not necessary anymore.